### PR TITLE
Update iframe.html

### DIFF
--- a/jamf_zendesk/assets/iframe.html
+++ b/jamf_zendesk/assets/iframe.html
@@ -108,7 +108,7 @@
                 client.metadata().then(function(metadata) {
                   $("#results").html(
                     '<span style="font-weight:bold">Multiple Devices Found For User</span>' + "<br>" +
-                    '<a href="' + jamfurl + '.jamfcloud.com/users.html?query=' + useremail + '" target="_blank">View User in Jamf Pro</a>' + "<br>" + "<br>" +
+                    '<a href="' + jamfurl + '/users.html?query=' + useremail + '" target="_blank">View User in Jamf Pro</a>' + "<br>" + "<br>" +
                     '<select id="cat">' +
                     '<option value="accounts/username/">Accounts By Username</option>' +
                     '<option value="computers/match/">Computer By Keyword</option>' +


### PR DESCRIPTION
In the case that an on premise JAMF Pro server exists, the URL within the iframe.html on line 111 contains a reference to ".jamfcloud.com." This will result in a blank page when clicking the "View User in Jamf Pro" link within Zendesk. Removing the reference to .jamfcloud.com is necessary for on premise users of Jamf Pro. I would recommend two releases of the Zendesk application, one for hosted/on premise users and one for Jamf Cloud users, each containing the appropriate HTML code for each.